### PR TITLE
Better, more future proof Fiona and Shapely usage

### DIFF
--- a/conflate/parsers/parse_flickr.py
+++ b/conflate/parsers/parse_flickr.py
@@ -1,6 +1,6 @@
 import demjson  #flickr geojson is not quite valid json, suffers from trailing commas
 import sys
-from shapely.geometry import asShape
+from shapely.geometry import shape
 import codecs
 #python parse_flickr.py /path/to/flickrShapeFile.geojson | psql gaztest
 #continents , counties, countries, localities, neighbourhoods, regions
@@ -23,7 +23,7 @@ def parse_flickr_geojson(flickr_file):
         feature_code = str(feature['properties']['place_type_id'])
         json_geometry  = feature['geometry']
         updated = "2011-01-08 00:00:00+00"  #i.e. as from http://code.flickr.com/blog/2011/01/08/flickr-shapefiles-public-dataset-2-0/
-        geometry = asShape(json_geometry).wkt
+        geometry = shape(json_geometry).wkt
 
         out_line = ['F', woe_id, name, feature_type, feature_code, updated, geometry ]
         

--- a/etl/parser/admin_0_1_natearth.py
+++ b/etl/parser/admin_0_1_natearth.py
@@ -1,8 +1,8 @@
 import sys, json, os, datetime
 import csv
 import codecs
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 import core
@@ -17,13 +17,13 @@ def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     csvfile = open('admin_csv_file', 'wb')
     csv_writer = csv.writer( csvfile, delimiter='\t') 
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
     
         geometry = feature["geometry"]
         properties = feature["properties"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
         try:
             centroid = [geom_obj.centroid.x , geom_obj.centroid.y]    
         except AttributeError:

--- a/etl/parser/digitizer_shapefile.py
+++ b/etl/parser/digitizer_shapefile.py
@@ -1,7 +1,7 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 from feature_type_maps.digitizer_types import use_types_map, use_sub_types_map
@@ -9,7 +9,7 @@ from feature_type_maps.digitizer_types import use_types_map, use_sub_types_map
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
@@ -20,7 +20,7 @@ def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
         del properties["updated_at"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
         try:
             centroid = [geom_obj.centroid.x , geom_obj.centroid.y]    
         except AttributeError:

--- a/etl/parser/hmdb.py
+++ b/etl/parser/hmdb.py
@@ -1,7 +1,7 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 import core
@@ -12,13 +12,13 @@ import codecs
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
 
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
     
         geometry = feature["geometry"]
         properties = feature["properties"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
         centroid = feature["geometry"]["coordinates"]
 
         name = properties["name"]

--- a/etl/parser/nhgis.py
+++ b/etl/parser/nhgis.py
@@ -1,7 +1,7 @@
 import sys, json, os, datetime, glob
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 
@@ -13,11 +13,11 @@ def extract_shapefile(shapefile, uri_name, simplify_tolerance):
     #with collection(shapefile, 'r') as source:
     #  #print country_code, geo_type, year, os.path.basename(shapefile), source.schema["properties"].keys()
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
         
         if simplify_tolerance:
             geometry = mapping(geom_obj.simplify(simplify_tolerance))

--- a/etl/parser/nrhp.py
+++ b/etl/parser/nrhp.py
@@ -1,7 +1,7 @@
 import sys, json, os, datetime, glob, codecs
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump, tab_file
 

--- a/etl/parser/nyc_brooklyn_digitizer.py
+++ b/etl/parser/nyc_brooklyn_digitizer.py
@@ -1,7 +1,7 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 from feature_type_maps.digitizer_types import use_types_map, use_sub_types_map
@@ -11,7 +11,7 @@ from feature_type_maps.digitizer_types import use_types_map, use_sub_types_map
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
@@ -22,7 +22,7 @@ def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
         del properties["updated_at"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
         if simplify_tolerance:
             geom_obj = geom_obj.simplify(simplify_tolerance)
         

--- a/etl/parser/nyc_buildings2010_shp.py
+++ b/etl/parser/nyc_buildings2010_shp.py
@@ -1,7 +1,7 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 from feature_type_maps.digitizer_types import use_types_map, use_sub_types_map
@@ -9,13 +9,13 @@ from feature_type_maps.digitizer_types import use_types_map, use_sub_types_map
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
 
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
 
         if simplify_tolerance:
             geom_obj = geom_obj.simplify(simplify_tolerance)

--- a/etl/parser/nyc_hist_counties_shapefile.py
+++ b/etl/parser/nyc_hist_counties_shapefile.py
@@ -1,20 +1,20 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
         if simplify_tolerance:
             geom_obj = geom_obj.simplify(simplify_tolerance)
         

--- a/etl/parser/nyc_hist_states_shapefile.py
+++ b/etl/parser/nyc_hist_states_shapefile.py
@@ -1,19 +1,19 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
         if simplify_tolerance:
             geom_obj = geom_obj.simplify(simplify_tolerance)
         

--- a/etl/parser/nyc_landmarks_polygons.py
+++ b/etl/parser/nyc_landmarks_polygons.py
@@ -1,20 +1,20 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
 
         try:
             centroid = [geom_obj.centroid.x , geom_obj.centroid.y]    

--- a/etl/parser/nyc_landmarks_shapefile.py
+++ b/etl/parser/nyc_landmarks_shapefile.py
@@ -1,19 +1,19 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
 
         try:
             centroid = [geom_obj.centroid.x , geom_obj.centroid.y]    

--- a/etl/parser/nyc_nrhp_csv.py
+++ b/etl/parser/nyc_nrhp_csv.py
@@ -1,7 +1,7 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump, tab_file
 

--- a/etl/parser/nyc_perris_digitizer_csv.py
+++ b/etl/parser/nyc_perris_digitizer_csv.py
@@ -1,8 +1,8 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
+from shapely.geometry import shape, mapping
 from shapely import wkt
-from fiona import collection
+import fiona
 
 from feature_type_maps.digitizer_types import use_types_map, use_sub_types_map
 

--- a/etl/parser/nyc_queens_digitizer.py
+++ b/etl/parser/nyc_queens_digitizer.py
@@ -1,7 +1,7 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 from feature_type_maps.digitizer_types import use_types_map, use_sub_types_map
@@ -9,7 +9,7 @@ from feature_type_maps.digitizer_types import use_types_map, use_sub_types_map
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
@@ -20,7 +20,7 @@ def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
         del properties["updated_at"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
 
         if simplify_tolerance:
             geom_obj = geom_obj.simplify(simplify_tolerance)

--- a/etl/parser/nyc_tax_block.py
+++ b/etl/parser/nyc_tax_block.py
@@ -1,20 +1,20 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
 
         try:
             centroid = [geom_obj.centroid.x , geom_obj.centroid.y]    

--- a/etl/parser/nyc_tax_lot.py
+++ b/etl/parser/nyc_tax_lot.py
@@ -1,20 +1,20 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
 
         try:
             centroid = [geom_obj.centroid.x , geom_obj.centroid.y]    

--- a/etl/parser/nyc_township_shapefile_1990.py
+++ b/etl/parser/nyc_township_shapefile_1990.py
@@ -1,20 +1,20 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
 
         try:
             centroid = [geom_obj.centroid.x , geom_obj.centroid.y]    

--- a/etl/parser/nyc_township_shapefile_2000.py
+++ b/etl/parser/nyc_township_shapefile_2000.py
@@ -1,20 +1,20 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
 
         try:
             centroid = [geom_obj.centroid.x , geom_obj.centroid.y]    

--- a/etl/parser/nyc_township_shapefile_2010.py
+++ b/etl/parser/nyc_township_shapefile_2010.py
@@ -1,20 +1,20 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 
 
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
         
         geometry = feature["geometry"]
         properties = feature["properties"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
 
         try:
             centroid = [geom_obj.centroid.x , geom_obj.centroid.y]    

--- a/etl/parser/tiger_line.py
+++ b/etl/parser/tiger_line.py
@@ -1,7 +1,7 @@
 import sys, json, os, datetime
 
-from shapely.geometry import asShape, mapping
-from fiona import collection
+from shapely.geometry import shape, mapping
+import fiona
 
 from core import Dump
 import core
@@ -16,13 +16,13 @@ import codecs
 def extract_shapefile(shapefile, uri_name, simplify_tolerance=None):
 
     
-    for feature in collection(shapefile, "r"):
+    for feature in fiona.open(shapefile, "r"):
     
         geometry = feature["geometry"]
         properties = feature["properties"]
         
         #calculate centroid
-        geom_obj = asShape(geometry)
+        geom_obj = shape(geometry)
         try:
             centroid = [geom_obj.centroid.x , geom_obj.centroid.y]    
         except AttributeError:


### PR DESCRIPTION
Hi, Sean Gillies here, the author of Fiona and Shapely. I'm very pleased to see them being used in your project! Shapely is a spin off of the [Pleiades Project](http://pleiades.stoa.org), a gazetteer of the ancient world. Gazetteers helping gazetteers :)

This pull request will future proof your ETL scripts. The `shapely.geometry.asShape()` and `fiona.collection()` methods aren't for developers. I've replaced them with calls to `shapely.geometry.shape()` and `fiona.open()`, documented methods of the public APIs of those packages.
